### PR TITLE
Fix encode_binary_time for ~T[00:00:00]

### DIFF
--- a/lib/myxql/protocol/values.ex
+++ b/lib/myxql/protocol/values.ex
@@ -276,10 +276,10 @@ defmodule MyXQL.Protocol.Values do
   ## Time/DateTime
 
   # MySQL supports negative time and days, we don't.
-  # See: https://dev.mysql.com/doc/internals/en/binary-protocol-value.html#packet-ProtocolBinary::MYSQL_TYPE_TIME
+  # See: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row_value_time
 
   defp encode_binary_time(%Time{hour: 0, minute: 0, second: 0, microsecond: {0, 0}}) do
-    {:mysql_type_time, <<0>>}
+    {:mysql_type_time, <<1>>}
   end
 
   defp encode_binary_time(%Time{hour: hour, minute: minute, second: second, microsecond: {0, 0}}) do

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -109,6 +109,18 @@ defmodule MyXQL.Protocol.ValueTest do
         assert insert_and_get(c, "my_time", ~T[09:10:20.123]) == ~T[09:10:20]
       end
 
+      test "MYSQL_TYPE_TIME - should pass examples from https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row_value_time",
+           c do
+        assert_roundtrip(c, "my_time6", ~T[19:27:30.000001])
+        assert insert_and_get(c, "my_time6", ~T[19:27:30.000001]) == ~T[19:27:30.000001]
+
+        assert_roundtrip(c, "my_time", ~T[19:27:30])
+        assert insert_and_get(c, "my_time", ~T[19:27:30]) == ~T[19:27:30]
+
+        assert_roundtrip(c, "my_time", ~T[00:00:00])
+        assert insert_and_get(c, "my_time", ~T[00:00:00]) == ~T[00:00:00]
+      end
+
       if @protocol == :binary do
         test "MYSQL_TYPE_TIME - negative time", c do
           assert_raise ArgumentError, ~r"cannot decode \"-01:00:00\" as time", fn ->


### PR DESCRIPTION
As per https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html:


```code
ProtocolBinary::MYSQL_TYPE_TIME:
type to store a TIME field in the binary protocol.

to save space the packet can be compressed:

if days, hours, minutes, seconds and micro_seconds are all 0, length is 0 and no other field is sent

if micro_seconds is 0, length is 8 and micro_seconds is not sent

otherwise length is 12

Fields
length ([1](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-1)) -- number of bytes following (valid values: 0, 8, 12)

is_negative ([1](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-1)) -- (1 if minus, 0 for plus)

days ([4](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-4)) -- days

hours ([1](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-1)) -- hours

minutes ([1](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-1)) -- minutes

seconds ([1](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-1)) -- seconds

micro_seconds ([4](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/describing-packets.html#type-4)) -- micro-seconds

Example

0c 01 78 00 00 00 13 1b 1e 01 00 00 00 -- time  -120d 19:27:30.000 001
08 01 78 00 00 00 13 1b 1e             -- time  -120d 19:27:30
01                                     -- time     0d 00:00:00

Implemented By
[Protocol_binary::store_time()](https://web.archive.org/web/20200616223324/https://dev.mysql.com/doc/internals/en/binary-protocol-type-implementation.html#Protocol_binary::store_time__X)
```

In the example, we can see three base16 encoded packets, and `~T[00:00:00]` should be: `01`, which is `<<1>>` in Elixir.

I have added tests that are failing for mysql:8.0 with the error:  
```
** (MyXQL.Error) (1835) Malformed communication packet.
```

as @wnoonan pointed out in https://github.com/elixir-ecto/ecto/issues/4045#issuecomment-1444613128 by completly avoiding the compression for `~T[00:00:00]` then we can avoid getting `Malformed communication packet` on the mysql:8.0 containers.

@wnoonan, do you mind testing this in your environment?



